### PR TITLE
Don't skip NamedTuple tests on 3.11+. Also make them pass on 3.11+.

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3643,11 +3643,11 @@ class AllTests(BaseTestCase):
         if sys.version_info < (3, 10, 1):
             exclude |= {"Literal"}
         if sys.version_info < (3, 11):
-            exclude |= {'final', 'NamedTuple', 'Any'}
+            exclude |= {'final', 'Any'}
         if sys.version_info < (3, 12):
             exclude |= {
                 'Protocol', 'runtime_checkable', 'SupportsIndex', 'TypedDict',
-                'is_typeddict'
+                'is_typeddict', 'NamedTuple',
             }
         for item in typing_extensions.__all__:
             if item not in exclude and hasattr(typing, item):
@@ -3694,7 +3694,6 @@ class XRepr(NamedTuple):
         return 0
 
 
-@skipIf(TYPING_3_11_0, "These invariants should all be tested upstream on 3.11+")
 class NamedTupleTests(BaseTestCase):
     class NestedEmployee(NamedTuple):
         name: str
@@ -3834,7 +3833,9 @@ class NamedTupleTests(BaseTestCase):
                 self.assertIs(type(a), G)
                 self.assertEqual(a.x, 3)
 
-                with self.assertRaisesRegex(TypeError, 'Too many parameters'):
+                things = "arguments" if sys.version_info >= (3, 11) else "parameters"
+
+                with self.assertRaisesRegex(TypeError, f'Too many {things}'):
                     G[int, str]
 
     @skipUnless(TYPING_3_9_0, "tuple.__class_getitem__ was added in 3.9")

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2327,10 +2327,11 @@ if not hasattr(typing, "TypeVarTuple"):
     typing._check_generic = _check_generic
 
 
-# Backport typing.NamedTuple as it exists in Python 3.11.
+# Backport typing.NamedTuple as it exists in Python 3.12.
 # In 3.11, the ability to define generic `NamedTuple`s was supported.
 # This was explicitly disallowed in 3.9-3.10, and only half-worked in <=3.8.
-if sys.version_info >= (3, 11):
+# On 3.12, we added __orig_bases__ to call-based NamedTuples
+if sys.version_info >= (3, 12):
     NamedTuple = typing.NamedTuple
 else:
     def _make_nmtuple(name, types, module, defaults=()):


### PR DESCRIPTION
I was confused about why the NamedTuple tests were passing on 3.11 -- they _shouldn't have been_! (See my comment here for an expalnation why: https://github.com/python/typing_extensions/pull/150#pullrequestreview-1396937557).

I realised I was the culprit here: https://github.com/python/typing_extensions/blame/main/src/test_typing_extensions.py#L3787 😆

This PR makes it so that we don't skip the tests on 3.11+. It also makes the newly-unskipped tests pass on 3.11!